### PR TITLE
chore: add .DS_Store and KUBECON_SUBMISSION.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ internal-docs/
 
 # Slide narrative reference (working document, not public content)
 SLIDE_NARRATIVE.md
+
+# macOS metadata
+.DS_Store
+
+# KubeCon submission (private)
+KUBECON_SUBMISSION.md


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to gitignore (macOS metadata)
- Add `KUBECON_SUBMISSION.md` to gitignore (private submission doc)

## Test plan
- [x] Verify `.gitignore` syntax is correct
- [x] Confirm no other untracked files affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to ignore additional files from version control, including macOS system files and submission-related documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->